### PR TITLE
Use sandbox flag in generation of auth url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-finch-connect",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "",
   "author": "",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export const useFinchConnect = (options = {}) => {
     zIndex = 999,
   } = options;
 
-  const _constructAuthUrl = (clientId, products) => {
+  const _constructAuthUrl = (clientId, products, sandbox) => {
     const authUrl = new URL(`${BASE_FINCH_CONNECT_URI}/authorize`);
 
     if (clientId) authUrl.searchParams.append('client_id', clientId);

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export const useFinchConnect = (options = {}) => {
     }
 
     const iframe = document.createElement('iframe');
-    iframe.src = _constructAuthUrl(clientId, products);
+    iframe.src = _constructAuthUrl(clientId, products, sandbox);
     iframe.frameBorder = '0';
     iframe.id = FINCH_CONNECT_IFRAME_ID;
     iframe.style.position = 'fixed';


### PR DESCRIPTION
### What

Use sandbox mode in the generation of auth URL.

### Why

Sandbox mode doesn't work with the SDK because the 'sandbox' flag
is not used when generating the auth URL. This intends to fix the issue.