### PR TITLE
chore(deps): unpin React peer dependency

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -18,8 +18,7 @@
       }
     },
     "..": {
-      "name": "react-finch-connect",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "integrity": "sha512-rBCol2cSPKsWYJhEtWKUgpoCSKWaO7/EVsG8JausuqCjx1jP3qNzuaLQHzHPiQs3Reax4Rn+Oe6iyqWGtgJk5w==",
       "license": "MIT",
       "devDependencies": {
@@ -61,7 +60,7 @@
         "eslint-plugin-standard": "^3.1.0",
         "gh-pages": "^2.0.1",
         "prettier": "^2.0.5",
-        "react": "^16.9.0",
+        "react": "17",
         "react-scripts": "^3.4.0",
         "react-test-renderer": "^16.9.0",
         "rollup": "^1.1.2",
@@ -77,7 +76,7 @@
         "npm": ">=5"
       },
       "peerDependencies": {
-        "react": "^16.9.0"
+        "react": ">=16.9.0"
       }
     },
     "../node_modules/@babel/code-frame": {
@@ -47049,7 +47048,7 @@
         "eslint-plugin-standard": "^3.1.0",
         "gh-pages": "^2.0.1",
         "prettier": "^2.0.5",
-        "react": "^16.9.0",
+        "react": "17",
         "react-scripts": "^3.4.0",
         "react-test-renderer": "^16.9.0",
         "rollup": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-finch-connect",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-finch-connect",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.0.0",
@@ -63,7 +63,7 @@
         "npm": ">=5"
       },
       "peerDependencies": {
-        "react": "^16.9.0"
+        "react": ">=16.9.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-finch-connect",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "",
   "author": "",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "predeploy": "cd example && npm install && npm run build"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
### What

Addresses #17 

React >= 16 should be sufficient here as a peer dependency, and will allow developers using React 17/18 to generate lock files correctly.

### Why

Hooks are the main React feature required by this library, so any version that supports that should work.
