### PR TITLE
Update README with all current options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ const App = () => {
 
   const { open } = useFinchConnect({
     clientId: '<your-client-id>',
+    // The below are only a few of Finch's product scopes, please check Finch's [documentation](https://developer.tryfinch.com/docs/reference/ZG9jOjMxOTg1NTI3-permissions) for the full list
     products: ['company', 'directory'],
+    // Check Finch's [documentation](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers) for the full list of payroll provider IDs
     // payrollProvider: '<payroll-provider-id>',
-    // sandbox: true,
+    // sandbox: false,
+    // manual: false,
+    // z-index: 999,
     onSuccess,
     onError,
     onClose,


### PR DESCRIPTION
Currently the README leaves out the options `manual` and `z-index`. This PR mentions them specifically.
Documentation links have also been added to the `products` and `payrollProvider` parameters as code comments.