### PR TITLE
Add redirectUri prop

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-finch-connect' {
     onError?: (e: ErrorEvent) => void;
     onClose?: () => void;
     zIndex?: bigint | string;
+    redirectUri: string;
   };
 
   export function useFinchConnect(opts: ConnectOptions): { open: () => void };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export const useFinchConnect = (options = {}) => {
     onError = noop,
     onClose = noop,
     zIndex = 999,
+    redirectUri = DEFAULT_FINCH_REDIRECT_URI,
   } = options;
 
   const _constructAuthUrl = (clientId, products) => {
@@ -29,7 +30,7 @@ export const useFinchConnect = (options = {}) => {
     if (payrollProvider) authUrl.searchParams.append('payroll_provider', payrollProvider);
     authUrl.searchParams.append('products', products.join(' '));
     authUrl.searchParams.append('app_type', 'spa');
-    authUrl.searchParams.append('redirect_uri', DEFAULT_FINCH_REDIRECT_URI);
+    authUrl.searchParams.append('redirect_uri', redirectUri);
     authUrl.searchParams.append('mode', mode);
     if (manual) authUrl.searchParams.append('manual', manual);
     if (sandbox) authUrl.searchParams.append('sandbox', sandbox);


### PR DESCRIPTION
On finch [docs](https://developer.tryfinch.com/docs/reference/61cff54e1d9b3-your-application-redirects-to-finch-connect#retrieve-the-authorization-code) it says:

If the user grants your application access and successfully connects their account, they are redirected to the specified `redirect_uri` with the query parameters below. You will have to ensure the listener at the `redirect_uri`, which can be either on the front or back-end, can parse the `code` out of the uri.

But we cannot use the React SDK and specify the `redirect_uri` on our backend without this change otherwise it will return an invalid code error
